### PR TITLE
Typo correction for PluginCommandInterfaceDbus and PluginControlInterface

### DIFF
--- a/PluginCommandInterfaceDbus/include/CAmDbusMessageHandler.h
+++ b/PluginCommandInterfaceDbus/include/CAmDbusMessageHandler.h
@@ -115,7 +115,7 @@ private:
     std::string mErrorName;
     std::string mErrorMsg;
     DBusMessage* mpDBusMessage;
-    DBusMessage* mpReveiveMessage;
+    DBusMessage* mpReceiveMessage;
     DBusConnection* mpDBusConnection;
 };
 

--- a/PluginCommandInterfaceDbus/src/CAmDbusMessageHandler.cpp
+++ b/PluginCommandInterfaceDbus/src/CAmDbusMessageHandler.cpp
@@ -35,7 +35,7 @@ CAmDbusMessageHandler::CAmDbusMessageHandler() :
         mErrorName(""), //
         mErrorMsg(""), //
         mpDBusMessage(NULL), //
-        mpReveiveMessage(NULL), //
+        mpReceiveMessage(NULL), //
         mpDBusConnection(NULL)
 {
    // CAmDltWrapper::instance()->registerContext(commandDbus, "DBP", "DBus Plugin");
@@ -50,7 +50,7 @@ CAmDbusMessageHandler::~CAmDbusMessageHandler()
 void CAmDbusMessageHandler::initReceive(DBusMessage* msg)
 {
     assert(msg!=NULL);
-    mpReveiveMessage = msg;
+    mpReceiveMessage = msg;
     if (!dbus_message_iter_init(msg, &mDBusMessageIter))
     {
         log(&commandDbus, DLT_LOG_INFO, "DBusMessageHandler::initReceive DBus Message has no arguments!");
@@ -90,9 +90,9 @@ void CAmDbusMessageHandler::initSignal(std::string path, std::string signalName)
 void CAmDbusMessageHandler::sendMessage()
 {
     assert(mpDBusConnection!=NULL);
-    if (mpReveiveMessage != 0)
+    if (mpReceiveMessage != 0)
     {
-        mSerial = dbus_message_get_serial(mpReveiveMessage);
+        mSerial = dbus_message_get_serial(mpReceiveMessage);
     }
     else
     {
@@ -100,7 +100,7 @@ void CAmDbusMessageHandler::sendMessage()
     }
     if (!mErrorName.empty())
     {
-        mpDBusMessage = dbus_message_new_error(mpReveiveMessage, mErrorName.c_str(), mErrorMsg.c_str());
+        mpDBusMessage = dbus_message_new_error(mpReceiveMessage, mErrorName.c_str(), mErrorMsg.c_str());
     }
     if (!dbus_connection_send(mpDBusConnection, mpDBusMessage, &mSerial))
     {
@@ -109,7 +109,7 @@ void CAmDbusMessageHandler::sendMessage()
     dbus_connection_flush(mpDBusConnection);
     dbus_message_unref(mpDBusMessage);
     mpDBusMessage = NULL;
-    mpReveiveMessage = NULL;
+    mpReceiveMessage = NULL;
 }
 
 char* CAmDbusMessageHandler::getString()

--- a/PluginControlInterface/include/CAmControlSenderBase.h
+++ b/PluginControlInterface/include/CAmControlSenderBase.h
@@ -107,7 +107,7 @@ private:
     struct mainConnectionSet
     {
         am_mainConnectionID_t connectionID;
-        std::vector<handleStatus> listHandleStaus;
+        std::vector<handleStatus> listHandleStatus;
     };
 
     struct mainVolumeSet

--- a/PluginControlInterface/include/IAmControlReceiverShadow.h
+++ b/PluginControlInterface/include/IAmControlReceiverShadow.h
@@ -63,9 +63,10 @@ public:
     am_Error_e changeSinkMainVolumeDB(am_mainVolume_t mainVolume, am_sinkID_t sinkID);
     am_Error_e changeSinkAvailabilityDB(am_Availability_s& availability, am_sinkID_t sinkID);
     am_Error_e changeDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID);
-    inline am_Error_e changeDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID)
+    inline am_Error_e changDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID)
     {
-        return changDomainStateDB(domainState, domainID);
+        //inline redirecetion (changDomainStateDB > changeDomainStateDB) for downward compatibility
+        return changeDomainStateDB(domainState, domainID);
     }
     am_Error_e changeSinkMuteStateDB(am_MuteState_e muteState, am_sinkID_t sinkID);
     am_Error_e changeMainSinkSoundPropertyDB(am_MainSoundProperty_s& soundProperty, am_sinkID_t sinkID);

--- a/PluginControlInterface/include/IAmControlReceiverShadow.h
+++ b/PluginControlInterface/include/IAmControlReceiverShadow.h
@@ -62,7 +62,11 @@ public:
     am_Error_e changeMainConnectionStateDB(am_mainConnectionID_t mainconnectionID, am_ConnectionState_e connectionState);
     am_Error_e changeSinkMainVolumeDB(am_mainVolume_t mainVolume, am_sinkID_t sinkID);
     am_Error_e changeSinkAvailabilityDB(am_Availability_s& availability, am_sinkID_t sinkID);
-    am_Error_e changDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID);
+    am_Error_e changeDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID);
+    inline am_Error_e changeDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID)
+    {
+        return changDomainStateDB(domainState, domainID);
+    }
     am_Error_e changeSinkMuteStateDB(am_MuteState_e muteState, am_sinkID_t sinkID);
     am_Error_e changeMainSinkSoundPropertyDB(am_MainSoundProperty_s& soundProperty, am_sinkID_t sinkID);
     am_Error_e changeMainSourceSoundPropertyDB(am_MainSoundProperty_s& soundProperty, am_sourceID_t sourceID);

--- a/PluginControlInterface/src/CAmControlSenderBase.cpp
+++ b/PluginControlInterface/src/CAmControlSenderBase.cpp
@@ -458,11 +458,11 @@ void CAmControlSenderBase::cbAckConnect(const am_Handle_s handle, const am_Error
         handleStatus status;
         status.status = true;
         status.handle = handle;
-        hit = std::find_if(it->listHandleStaus.begin(), it->listHandleStaus.end(), findHandle(status));
-        if (hit == it->listHandleStaus.end())
+        hit = std::find_if(it->listHandleStatus.begin(), it->listHandleStatus.end(), findHandle(status));
+        if (hit == it->listHandleStatus.end())
             continue;
         hit->status = true;
-        if (it->listHandleStaus.end() == std::find_if(it->listHandleStaus.begin(), it->listHandleStaus.end(), checkHandle(status)))
+        if (it->listHandleStatus.end() == std::find_if(it->listHandleStatus.begin(), it->listHandleStatus.end(), checkHandle(status)))
         {
             mControlReceiveInterface->changeMainConnectionStateDB(it->connectionID, CS_CONNECTED);
             mListOpenConnections.erase(it);
@@ -483,11 +483,11 @@ void CAmControlSenderBase::cbAckDisconnect(const am_Handle_s handle, const am_Er
         handleStatus status;
         status.status = true;
         status.handle = handle;
-        hit = std::find_if(it->listHandleStaus.begin(), it->listHandleStaus.end(), findHandle(status));
-        if (hit == it->listHandleStaus.end())
+        hit = std::find_if(it->listHandleStatus.begin(), it->listHandleStatus.end(), findHandle(status));
+        if (hit == it->listHandleStatus.end())
             continue;
         hit->status = true;
-        if (it->listHandleStaus.end() == std::find_if(it->listHandleStaus.begin(), it->listHandleStaus.end(), checkHandle(status)))
+        if (it->listHandleStatus.end() == std::find_if(it->listHandleStatus.begin(), it->listHandleStatus.end(), checkHandle(status)))
         {
             mControlReceiveInterface->removeMainConnectionDB(it->connectionID);
             mListOpenDisconnections.erase(it);
@@ -608,7 +608,7 @@ void CAmControlSenderBase::disconnect(am_mainConnectionID_t connectionID)
     }
 
     std::vector<am_connectionID_t>::iterator it(mainConnection.listConnectionID.begin());
-    std::vector<handleStatus> listHandleStaus;
+    std::vector<handleStatus> listHandleStatus;
     for (; it != mainConnection.listConnectionID.end(); ++it)
     {
         handleStatus status;
@@ -617,11 +617,11 @@ void CAmControlSenderBase::disconnect(am_mainConnectionID_t connectionID)
         {
             logError("Could not disconnect, Error", error);
         }
-        listHandleStaus.push_back(status);
+        listHandleStatus.push_back(status);
     }
     mainConnectionSet set;
     set.connectionID = connectionID;
-    set.listHandleStaus = listHandleStaus;
+    set.listHandleStatus = listHandleStatus;
     mListOpenDisconnections.push_back(set);
 }
 
@@ -635,7 +635,7 @@ void CAmControlSenderBase::connect(am_sourceID_t sourceID, am_sinkID_t sinkID, a
     if (listRoutes.empty())
         logError("CAmControlSenderBase::connect not possible");
 
-    std::vector<handleStatus> listHandleStaus;
+    std::vector<handleStatus> listHandleStatus;
     std::vector<am_RoutingElement_s>::iterator it(listRoutes[0].route.begin());
     for (; it != listRoutes[0].route.end(); ++it)
     {
@@ -644,12 +644,12 @@ void CAmControlSenderBase::connect(am_sourceID_t sourceID, am_sinkID_t sinkID, a
         handleStatus status;
         status.handle = handle;
         status.status = false;
-        listHandleStaus.push_back(status);
+        listHandleStatus.push_back(status);
         listConnectionIDs.push_back(connectionID);
     }
     mainConnectionSet set;
     set.connectionID = mainConnectionID;
-    set.listHandleStaus = listHandleStaus;
+    set.listHandleStatus = listHandleStatus;
     mControlReceiveInterface->changeMainConnectionRouteDB(mainConnectionID,listConnectionIDs);
     mListOpenConnections.push_back(set);
 }

--- a/PluginControlInterface/src/IAmControlReceiverShadow.cpp
+++ b/PluginControlInterface/src/IAmControlReceiverShadow.cpp
@@ -343,10 +343,10 @@ am_Error_e IAmControlReceiverShadow::changeSinkAvailabilityDB(am_Availability_s&
     return (error);
 }
 
-am_Error_e IAmControlReceiverShadow::changDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID)
+am_Error_e IAmControlReceiverShadow::changeDomainStateDB(am_DomainState_e domainState, am_domainID_t domainID)
 {
     am_Error_e error;
-    mCAmSerializer.syncCall<IAmControlReceive, am_Error_e, am_DomainState_e, const am_domainID_t, am_DomainState_e, am_domainID_t>(mpIAmControlReceiver, &IAmControlReceive::changDomainStateDB, error, domainState, domainID);
+    mCAmSerializer.syncCall<IAmControlReceive, am_Error_e, am_DomainState_e, const am_domainID_t, am_DomainState_e, am_domainID_t>(mpIAmControlReceiver, &IAmControlReceive::changeDomainStateDB, error, domainState, domainID);
     return (error);
 }
 

--- a/PluginControlInterface/test/MockIAmControlReceive.h
+++ b/PluginControlInterface/test/MockIAmControlReceive.h
@@ -85,7 +85,7 @@ class MockIAmControlReceive : public IAmControlReceive {
       am_Error_e(const am_mainVolume_t mainVolume, const am_sinkID_t sinkID));
   MOCK_METHOD2(changeSinkAvailabilityDB,
       am_Error_e(const am_Availability_s& availability, const am_sinkID_t sinkID));
-  MOCK_METHOD2(changDomainStateDB,
+  MOCK_METHOD2(changeDomainStateDB,
       am_Error_e(const am_DomainState_e domainState, const am_domainID_t domainID));
   MOCK_METHOD2(changeSinkMuteStateDB,
       am_Error_e(const am_MuteState_e muteState, const am_sinkID_t sinkID));

--- a/PluginControlInterfaceGeneric/src/CAmControllerPlugin.cpp
+++ b/PluginControlInterfaceGeneric/src/CAmControllerPlugin.cpp
@@ -1621,7 +1621,7 @@ void CAmControllerPlugin::hookSystemDomainStateChange(const am_domainID_t domain
     NULL_CHECK_AND_RETURN(mpControlReceive);
 
     // update the domain state in DB
-    mpControlReceive->changDomainStateDB(state, domainID);
+    mpControlReceive->changeDomainStateDB(state, domainID);
 }
 
 void CAmControllerPlugin::hookSystemReceiveEarlyData(const std::vector<am_EarlyData_s > &listData)

--- a/PluginControlInterfaceGeneric/src/CAmDomainElement.cpp
+++ b/PluginControlInterfaceGeneric/src/CAmDomainElement.cpp
@@ -65,7 +65,7 @@ am_Error_e CAmDomainElement::_unregister(void)
 
 am_Error_e CAmDomainElement::setState(const am_DomainState_e state)
 {
-    return mpControlReceive->changDomainStateDB(state, getID());
+    return mpControlReceive->changeDomainStateDB(state, getID());
 }
 
 am_Error_e CAmDomainElement::getState(int &state) const

--- a/PluginRoutingInterfaceDbus/include/CAmDbusMessageHandler.h
+++ b/PluginRoutingInterfaceDbus/include/CAmDbusMessageHandler.h
@@ -138,7 +138,7 @@ private:
     std::string mErrorName;
     std::string mErrorMsg;
     DBusMessage* mpDBusMessage;
-    DBusMessage* mpReveiveMessage;
+    DBusMessage* mpReceiveMessage;
     DBusConnection* mpDBusConnection;
 };
 

--- a/PluginRoutingInterfaceDbus/include/CAmDbusSend.h
+++ b/PluginRoutingInterfaceDbus/include/CAmDbusSend.h
@@ -38,6 +38,8 @@ public:
     void append(uint16_t integer);
     void append(int16_t integer);
     void append(int integer);
+    void append(const char* args, int16_t sizeOfArray);
+    void append(const unsigned char* args, int16_t sizeOfArray);
     void append(std::vector<am_SoundProperty_s> listSoundProperties);
     void append(am_SoundProperty_s soundProperty);
     am_Error_e send();

--- a/PluginRoutingInterfaceDbus/src/CAmDbusMessageHandler.cpp
+++ b/PluginRoutingInterfaceDbus/src/CAmDbusMessageHandler.cpp
@@ -37,7 +37,7 @@ CAmRoutingDbusMessageHandler::CAmRoutingDbusMessageHandler() :
         mErrorName(""), //
         mErrorMsg(""), //
         mpDBusMessage(NULL), //
-        mpReveiveMessage(NULL), //
+        mpReceiveMessage(NULL), //
         mpDBusConnection(NULL)
 {
     //CAmDltWrapper::instance()->registerContext(routingDbus, "DRS", "DBus Plugin");
@@ -52,7 +52,7 @@ CAmRoutingDbusMessageHandler::~CAmRoutingDbusMessageHandler()
 void CAmRoutingDbusMessageHandler::initReceive(DBusMessage* msg)
 {
     assert(msg!=NULL);
-    mpReveiveMessage = msg;
+    mpReceiveMessage = msg;
     if (!dbus_message_iter_init(msg, &mDBusMessageIter))
     {
         log(&routingDbus, DLT_LOG_INFO, "DBusMessageHandler::initReceive DBus Message has no arguments!");
@@ -92,9 +92,9 @@ void CAmRoutingDbusMessageHandler::initSignal(std::string path, std::string sign
 void CAmRoutingDbusMessageHandler::sendMessage()
 {
     assert(mpDBusConnection!=NULL);
-    if (mpReveiveMessage != 0)
+    if (mpReceiveMessage != 0)
     {
-        mSerial = dbus_message_get_serial(mpReveiveMessage);
+        mSerial = dbus_message_get_serial(mpReceiveMessage);
     }
     else
     {
@@ -102,7 +102,7 @@ void CAmRoutingDbusMessageHandler::sendMessage()
     }
     if (!mErrorName.empty())
     {
-        mpDBusMessage = dbus_message_new_error(mpReveiveMessage, mErrorName.c_str(), mErrorMsg.c_str());
+        mpDBusMessage = dbus_message_new_error(mpReceiveMessage, mErrorName.c_str(), mErrorMsg.c_str());
     }
     if (!dbus_connection_send(mpDBusConnection, mpDBusMessage, &mSerial))
     {

--- a/PluginRoutingInterfaceDbus/src/CAmDbusSend.cpp
+++ b/PluginRoutingInterfaceDbus/src/CAmDbusSend.cpp
@@ -76,6 +76,26 @@ void CAmRoutingDbusSend::append(int16_t integer)
     }
 }
 
+void CAmRoutingDbusSend::append(const char* args, int16_t sizeOfArray)
+{
+    dbus_message_iter_init_append(mpDbusMessage, &mDbusMessageIter);
+    if(!dbus_message_append_args(mpDbusMessage, DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &args, sizeOfArray, DBUS_TYPE_INVALID))
+    {
+        log(&routingDbus, DLT_LOG_ERROR, "CAmRoutingDbusSend::append no more memory");
+        this->~CAmRoutingDbusSend();
+    }
+}
+
+void CAmRoutingDbusSend::append(const unsigned char* args, int16_t sizeOfArray)
+{
+    dbus_message_iter_init_append(mpDbusMessage, &mDbusMessageIter);
+    if(!dbus_message_append_args(mpDbusMessage, DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &args, sizeOfArray, DBUS_TYPE_INVALID))
+    {
+        log(&routingDbus, DLT_LOG_ERROR, "CAmRoutingDbusSend::append no more memory");
+        this->~CAmRoutingDbusSend();
+    }
+}
+
 void CAmRoutingDbusSend::append(std::vector<am_SoundProperty_s> listSoundProperties)
 {
     DBusMessageIter arrayIter;


### PR DESCRIPTION
PluginCommandInterfaceDbus

typo correction from mpReveiveMessage to mpReceiveMessage(This changes doesn't affect to any other related interfaces.)
PluginControlInterface

typo correction changDomainStateDB to changeDomainStateDB(including inline redirection)
For downward compatibility, Inline redirection is added on IAmControlReceiverShadow.h for calling changDomainStateDB on AudioManager Core
typo correction listHandleStaus to listHandleStatus (This changes doesn't affect to any other related interfaces.)