### PR TITLE
Update CAmDbusSend.h

### DIFF
--- a/PluginRoutingInterfaceDbus/include/CAmDbusSend.h
+++ b/PluginRoutingInterfaceDbus/include/CAmDbusSend.h
@@ -38,6 +38,8 @@ public:
     void append(uint16_t integer);
     void append(int16_t integer);
     void append(int integer);
+    void append(const char* args, int16_t sizeOfArray);
+    void append(const unsigned char* args, int16_t sizeOfArray);
     void append(std::vector<am_SoundProperty_s> listSoundProperties);
     void append(am_SoundProperty_s soundProperty);
     am_Error_e send();


### PR DESCRIPTION
For the cases of sending D-Bus message with char or byte array, append options with (signed/unsigned) char are added